### PR TITLE
Compose from ruby:1.9.3 to specify MySQL 5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM bikebike/bikebike
 MAINTAINER Jonathan Rosenbaum <gnuser@gmail.com>
 
 RUN git clone git://github.com/asalant/freehub.git
-RUN gem install bundler
+RUN gem install bundler -v 1.15.4
 #RUN apt-get -y install ruby-dev
 RUN bundle install --gemfile=/freehub/Gemfile
 RUN service mysql start; cd /freehub; rake db:create:all; rake db:migrate; rake db:fixtures:load
@@ -17,4 +17,4 @@ COPY  freehub.conf /etc/supervisor/conf.d/
 
 CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]
 
-# docker run -d -p 3000:3000 --name="freehub" bikebike/freehub 
+# docker run -d -p 3000:3000 --name="freehub" bikebike/freehub

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,29 @@
 ###########
 # Password is test for greeter, sfbk, mechanic, scbc, cbi, admin
 
-FROM bikebike/bikebike
+FROM ruby:1.9.3
 MAINTAINER Jonathan Rosenbaum <gnuser@gmail.com>
 
+RUN apt-get update && apt-get install -y lsb-release git supervisor make
+
+# Install mysql 5.6
+# From https://www.debiantutorials.com/how-to-install-mysql-server-5-6-or-5-7/
+ENV DEBIAN_FRONTEND noninteractive
+RUN wget https://dev.mysql.com/get/mysql-apt-config_0.8.9-1_all.deb
+RUN echo mysql-apt-config mysql-apt-config/select-server select mysql-5.6 | debconf-set-selections
+RUN echo mysql-community-server mysql-community-server/root-pass password '' | debconf-set-selections
+RUN dpkg -i mysql-apt-config_0.8.9-1_all.deb
+RUN dpkg-preconfigure mysql-community-server_version-and-platform-specific-part.deb
+RUN apt-get update && apt-get install -y --force-yes mysql-community-server
+
+# Install freehub
 RUN git clone git://github.com/asalant/freehub.git
 RUN gem install bundler -v 1.15.4
-#RUN apt-get -y install ruby-dev
 RUN bundle install --gemfile=/freehub/Gemfile
-RUN service mysql start; cd /freehub; rake db:create:all; rake db:migrate; rake db:fixtures:load
+
+# Bootstrap freehub
+RUN chown -R mysql:mysql /var/lib/mysql /var/run/mysqld && service mysql start; \
+    cd /freehub; rake db:create:all; rake db:migrate; rake db:fixtures:load
 
 COPY  mysql.conf /etc/supervisor/conf.d/
 COPY  freehub.conf /etc/supervisor/conf.d/


### PR DESCRIPTION
DO NOT MERGE 

@fspc take a look at these changes. This is still in progress as I have not resolved a final issue that I will describe below in case you have the docker fu to figure what is going on.

I made these changes so that I could specify the same mysql version we are using in production at EngineYard. Actually, 5.6 is the version I am migrating to from 5.0 and I wanted to be able to test locally first.

It was super helpful to have your Dockerfile to start from and I think its a great idea to make it a core part of Freehub development, at least until it is running on more current versions of Ruby and Rails.

If you want to continue being the source of truth for the Docker setup for Freehub development, I am happy to push you changes and let you handle deploys to Docker Hub. If that sounds annoying, I'm happy to take it over. Just let me know which you prefer.

As for the issue I am having, the docker image is building fine but when running with:

```
docker run -d -p 3000:3000 --name="freehub" bikebike/freehub
```

The process exits immediately.

If I try debugging  by starting up with a shell:

```
docker run -it -p 3000:3000 bikebike/freehub /bin/bash
```

I can see that `supervisord` is not running and has not started mysql or freehub. But if I start it manually with:

```
supervisord -c /etc/supervisor/supervisord.conf 
```

It starts up fine. I've been looking at supervisord, docker, and mysql logs with no obvious clues. 

One clue might be that mysql file permissions appear to be an issue with Docker and mysql version 5.6. The line that starts mysql starts with `RUN chown -R mysql:mysql /var/lib/mysql /var/run/mysqld` which I found was required to get mysql to start (and was a solution I found from other users having the same problem).

I'll debug further but putting this up here in case you have a chance to look at it or have any tips on how to debug. Not ready to merge until this issue is resolved.
